### PR TITLE
Allow dots in tag names (e.g. T1.1) in brat2conllu converter

### DIFF
--- a/weaver/brat2conllu.pl
+++ b/weaver/brat2conllu.pl
@@ -82,7 +82,7 @@ while(<>)
         my ($deprel, $parent, $child);
         $ann =~ s/^\s+//;
         $ann =~ s/\s+$//;
-        if($ann =~ m/^(\S+)\s+Arg1:(T\d+)\s+Arg2:(T\d+)$/)
+        if($ann =~ m/^(\S+)\s+Arg1:(T[\d\.]+)\s+Arg2:(T[\d\.]+)$/)
         {
             $deprel = $1;
             $parent = $2;


### PR DESCRIPTION
Previously, the conversion failed outputting dependency relations and labels if the tag names contained dots, such as `T1.1`. This fix is fully due to @dan-zeman.
Resolves #3.